### PR TITLE
Add changes for deploying stac server through fabric service ci/cd

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "typecheck": "tsc",
     "audit-prod": "npx better-npm-audit audit --production",
     "audit": "npx better-npm-audit audit",
-    "deploy": "sls deploy",
+    "deploy": "sls deploy --verbose",
     "sls-remove": "sls remove",
     "package": "sls package",
     "serve": "REQUEST_LOGGING_FORMAT=dev LOG_LEVEL=debug STAC_API_URL=http://localhost:3000 ENABLE_TRANSACTIONS_EXTENSION=true nodemon --esm ./src/lambdas/api/local.ts",

--- a/serverless.yml
+++ b/serverless.yml
@@ -190,7 +190,7 @@ resources:
           GenerateStringKey: 'password'
           PasswordLength: 16
           IncludeSpace: false
-          ExcludeCharacters: '"@/\\:'
+          ExcludeCharacters: '"@/\\:#?&%+[]$'
     OpenSearchInstance:
       Type: AWS::OpenSearchService::Domain
       DependsOn: OpenSearchPassword

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,4 +1,4 @@
-service: fabric-stac-server-2
+service: fabric-stac-server-service
 
 provider:
   name: aws

--- a/serverless.yml
+++ b/serverless.yml
@@ -15,7 +15,7 @@ provider:
       accessLogging: false
       format: '{"requestId":"$context.requestId","ip":"$context.identity.sourceIp","caller":"$context.identity.caller","useragent" : "$context.identity.userAgent","requestTime":"$context.requestTime","httpMethod":"$context.httpMethod","resourcePath":"$context.resourcePath","status":"$context.status","protocol":"$context.protocol","responseLength":"$context.responseLength"}'
   environment:
-    STAC_ID: 'fabric-stac-server-2'
+    STAC_ID: ${self:service}
     STAC_TITLE: 'Fabric STAC API'
     STAC_DESCRIPTION: 'A STAC API using stac-server'
     LOG_LEVEL: debug
@@ -25,7 +25,7 @@ provider:
     OPENSEARCH_HOST:
       Fn::GetAtt: [OpenSearchInstance, DomainEndpoint]
     ENABLE_TRANSACTIONS_EXTENSION: false
-    OPENSEARCH_CREDENTIALS_SECRET_ID: fabric-${self:service}-${sls:stage}-opensearch-user-creds
+    OPENSEARCH_CREDENTIALS_SECRET_ID: ${self:service}-${sls:stage}-opensearch-user-creds
     # comment STAC_API_ROOTPATH if deployed with a custom domain
     STAC_API_ROOTPATH: '/${sls:stage}'
     # PRE_HOOK: ${self:service}-${sls:stage}-preHook
@@ -183,7 +183,7 @@ resources:
     OpenSearchPassword:
       Type: AWS::SecretsManager::Secret
       Properties:
-        Name: fabric-${sls:stage}-opensearch-user-creds
+        Name: ${self:service}-${sls:stage}-opensearch-user-creds
         Description: 'OpenSearch master user credentials for ${self:service} ${sls:stage}'
         GenerateSecretString:
           SecretStringTemplate: '{"username":"${self:service}-admin"}'
@@ -221,7 +221,7 @@ resources:
           InternalUserDatabaseEnabled: true
           MasterUserOptions:
             MasterUserName: ${self:service}-admin
-            MasterUserPassword: '{{resolve:secretsmanager:fabric-${sls:stage}-opensearch-user-creds:SecretString:password}}'
+            MasterUserPassword: '{{resolve:secretsmanager:${self:service}-${sls:stage}-opensearch-user-creds:SecretString:password}}'
         AccessPolicies:
           Version: '2012-10-17'
           Statement:

--- a/serverless.yml
+++ b/serverless.yml
@@ -183,11 +183,14 @@ resources:
     OpenSearchPassword:
       Type: AWS::SecretsManager::Secret
       Properties:
-        Name: ${self:service}-${sls:stage}-opensearch-password
-        Description: 'OpenSearch master user password for ${self:service} ${sls:stage}'
+        Name: fabric-${sls:stage}-opensearch-user-creds
+        Description: 'OpenSearch master user credentials for ${self:service} ${sls:stage}'
         GenerateSecretString:
+          SecretStringTemplate: '{"username":"${self:service}-admin"}'
+          GenerateStringKey: 'password'
           PasswordLength: 16
-          ExcludeCharacters: '"@/\\'
+          IncludeSpace: false
+          ExcludeCharacters: '"@/\\:'
     OpenSearchInstance:
       Type: AWS::OpenSearchService::Domain
       DependsOn: OpenSearchPassword
@@ -214,13 +217,11 @@ resources:
         EncryptionAtRestOptions:
           Enabled: true
         AdvancedSecurityOptions:
-          Enabled: true # enables fine-grained access control
+          Enabled: true
           InternalUserDatabaseEnabled: true
-          # When deploying to a new environment for this first time, the master user
-          # must be set. Afterwards it's optional
           MasterUserOptions:
             MasterUserName: ${self:service}-admin
-            MasterUserPassword: '{{resolve:secretsmanager:${self:service}-${sls:stage}-opensearch-password:SecretString}}'
+            MasterUserPassword: '{{resolve:secretsmanager:fabric-${sls:stage}-opensearch-user-creds:SecretString:password}}'
         AccessPolicies:
           Version: '2012-10-17'
           Statement:

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,4 +1,4 @@
-service: fabric-stac-server
+service: fabric-stac-server-2
 
 provider:
   name: aws
@@ -15,7 +15,7 @@ provider:
       accessLogging: false
       format: '{"requestId":"$context.requestId","ip":"$context.identity.sourceIp","caller":"$context.identity.caller","useragent" : "$context.identity.userAgent","requestTime":"$context.requestTime","httpMethod":"$context.httpMethod","resourcePath":"$context.resourcePath","status":"$context.status","protocol":"$context.protocol","responseLength":"$context.responseLength"}'
   environment:
-    STAC_ID: 'fabric-stac-server'
+    STAC_ID: 'fabric-stac-server-2'
     STAC_TITLE: 'Fabric STAC API'
     STAC_DESCRIPTION: 'A STAC API using stac-server'
     LOG_LEVEL: debug
@@ -25,7 +25,7 @@ provider:
     OPENSEARCH_HOST:
       Fn::GetAtt: [OpenSearchInstance, DomainEndpoint]
     ENABLE_TRANSACTIONS_EXTENSION: false
-    OPENSEARCH_CREDENTIALS_SECRET_ID: fabric-${sls:stage}-opensearch-user-creds
+    OPENSEARCH_CREDENTIALS_SECRET_ID: fabric-${self:service}-${sls:stage}-opensearch-user-creds
     # comment STAC_API_ROOTPATH if deployed with a custom domain
     STAC_API_ROOTPATH: '/${sls:stage}'
     # PRE_HOOK: ${self:service}-${sls:stage}-preHook

--- a/serverless.yml
+++ b/serverless.yml
@@ -5,7 +5,6 @@ provider:
   runtime: nodejs18.x
   stage: ${opt:stage, 'dev'}
   region: ${opt:region, 'us-east-1'}
-  profile: ${self:custom.stages.${sls:stage}.profile}
   # uncomment this if using a bucket that already exists for deployment files
   # deploymentBucket:
   #   name: my-deployment-bucket
@@ -21,8 +20,6 @@ provider:
     STAC_DESCRIPTION: 'A STAC API using stac-server'
     LOG_LEVEL: debug
     STAC_DOCS_URL: https://stac-utils.github.io/stac-server/
-    OPEN_SEARCH_MASTER_USERNAME: ${self:custom.opensearch_creds.username}
-    OPEN_SEARCH_MASTER_PASSWORD: ${self:custom.opensearch_creds.password}
     ITEMS_INDICIES_NUM_OF_SHARDS: 1
     ITEMS_INDICIES_NUM_OF_REPLICAS: 1
     OPENSEARCH_HOST:
@@ -39,6 +36,7 @@ provider:
     # STAC_API_URL: 'https://3auofrizcl.execute-api.us-east-1.amazonaws.com/stg'
     # CORS_ORIGIN: 'https://3auofrizcl.execute-api.us-east-1.amazonaws.com/stg'
     CORS_CREDENTIALS: false
+    IMAGERY_BUCKET_ARN: ${param:s3BucketArn}
   iam:
     role:
       statements:
@@ -70,8 +68,8 @@ provider:
             - s3:PutObject
             - s3:ListBucket
           Resource:
-            - 'arn:aws:s3:::fabric-${sls:stage}-stac-repository/*'
-            - 'arn:aws:s3:::fabric-${sls:stage}-stac-repository'
+            - '${self:provider.environment.IMAGERY_BUCKET_ARN}/*'
+            - '${self:provider.environment.IMAGERY_BUCKET_ARN}'
         # - Effect: Allow
         #   Action: lambda:InvokeFunction
         #   Resource: arn:aws:lambda:${aws:region}:${aws:accountId}:function:${self:service}-${sls:stage}-preHook
@@ -81,16 +79,6 @@ provider:
         # - Effect: Allow
         #   Action: lambda:InvokeFunction
         #   Resource: arn:aws:lambda:${aws:region}:${aws:accountId}:function:${self:service}-${sls:stage}-postHook
-
-custom:
-  stages:
-    dev:
-      profile: Fabric-Staging
-      POST_INGEST_EVENT_BUS_NAME: dev-fabric-bus
-    stg:
-      profile: Fabric-Staging
-      POST_INGEST_EVENT_BUS_NAME: staging-fabric-bus
-  opensearch_creds: ${ssm:/aws/reference/secretsmanager/fabric-${sls:stage}-opensearch-user-creds}
 
 package:
   individually: true
@@ -118,7 +106,7 @@ functions:
     environment:
       AWS_STAGE: ${sls:stage}
       POST_INGEST_TOPIC_ARN: !Ref postIngestTopic
-      POST_INGEST_EVENT_BUS_NAME: ${self:custom.stages.${sls:stage}.POST_INGEST_EVENT_BUS_NAME}
+      POST_INGEST_EVENT_BUS_NAME: ${sls:stage}-fabric-bus
     package:
       artifact: dist/ingest/ingest.zip
     events:
@@ -192,8 +180,17 @@ resources:
         Protocol: sqs
         Region: '${aws:region}'
         TopicArn: !Ref ingestTopic
+    OpenSearchPassword:
+      Type: AWS::SecretsManager::Secret
+      Properties:
+        Name: ${self:service}-${sls:stage}-opensearch-password
+        Description: 'OpenSearch master user password for ${self:service} ${sls:stage}'
+        GenerateSecretString:
+          PasswordLength: 16
+          ExcludeCharacters: '"@/\\'
     OpenSearchInstance:
       Type: AWS::OpenSearchService::Domain
+      DependsOn: OpenSearchPassword
       DeletionPolicy: Retain
       UpdateReplacePolicy: Retain
       UpdatePolicy:
@@ -222,8 +219,8 @@ resources:
           # When deploying to a new environment for this first time, the master user
           # must be set. Afterwards it's optional
           MasterUserOptions:
-            MasterUserName: ${self:provider.environment.OPEN_SEARCH_MASTER_USERNAME}
-            MasterUserPassword: ${self:provider.environment.OPEN_SEARCH_MASTER_PASSWORD}
+            MasterUserName: ${self:service}-admin
+            MasterUserPassword: '{{resolve:secretsmanager:${self:service}-${sls:stage}-opensearch-password:SecretString}}'
         AccessPolicies:
           Version: '2012-10-17'
           Statement:
@@ -239,6 +236,10 @@ resources:
         Fn::GetAtt: [OpenSearchInstance, DomainEndpoint]
       Export:
         Name: ${self:service}-${sls:stage}-os-endpoint
+    OpenSearchPassword:
+      Value: ${self:service}-${sls:stage}-opensearch-password
+      Export:
+        Name: ${self:service}-${sls:stage}-os-password-name
 
 plugins:
   - serverless-offline


### PR DESCRIPTION
## Description & Technical Solution

https://app.asana.com/0/1205260664956485/1209483456576005/f

Right now, the STAC server has been detached from our CI/CD process. This is an issue when we want to make updates to our STAC server, because it doesn't have any CI/CD process, it's all manual. This PR enables makes the necessary changes to the STAC server so that it can be deployed through the `fabric-service` makefile

## Changes

* Rename the service to `fabric-stac-server-2` to avoid clashes with the existing staging deployment that was deployed as a blind copy and not a fork of the `stac-utils` repo
* Add a required parameter `s3BucketArn` that specifies the bucket used for the imagery repository
* Add generating a password for the opensearch instance admin user, rather than assuming that the password is already deployed

## Testing Instructions

Testing can only be done in sandbox environments to avoid clashing with the deployment, but it can be done with
```
npm run deploy -- \
--stage dev \
--region us-east-1 \
--param="s3BucketArn=<INSERT_YOUR_BUCKET_ARN>" 
```

Good luck, and don't f**k it up