### PR TITLE
fix(serverless): fix(serverless): add missing env variables for ingest lambda

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -33,8 +33,10 @@ provider:
     # POST_HOOK: ${self:service}-${sls:stage}-postHook
     # If you will be subscribing to post-ingest SNS notifications make
     # sure that STAC_API_URL is set so that links are updated correctly
-    # STAC_API_URL: 'https://3auofrizcl.execute-api.us-east-1.amazonaws.com/stg'
-    # CORS_ORIGIN: 'https://3auofrizcl.execute-api.us-east-1.amazonaws.com/stg'
+    STAC_API_URL:
+      Fn::Sub: https://${ApiGatewayRestApi}.execute-api.${aws:region}.amazonaws.com/${sls:stage}
+    CORS_ORIGIN:
+      Fn::Sub: https://${ApiGatewayRestApi}.execute-api.${aws:region}.amazonaws.com/${sls:stage}
     CORS_CREDENTIALS: false
     IMAGERY_BUCKET_ARN: ${param:s3BucketArn}
   iam:


### PR DESCRIPTION
## Description & Technical Solution

No Asana Task.

During ingestion tests, it was noticed that some environment variables are missing for the lambda that does the ingestion.

## Changes

Add STAC_API_URL and CORS_ORIGIN to the lambda environment.

## Testing Instructions

No tests
