### PR TITLE
fix(api): add `ApiGatewayRestApi` as a prefix to `STAC_API_URL`

### DIFF
--- a/serverless-private-api.yml
+++ b/serverless-private-api.yml
@@ -40,7 +40,7 @@ provider:
     # comment STAC_API_ROOTPATH if deployed with a custom domain
     STAC_API_ROOTPATH: "/${sls:stage}"
     STAC_API_URL:
-      Fn::Sub: https://${param:vpcEndpointId}.execute-api.${aws:region}.amazonaws.com/${sls:stage}
+      Fn::Sub: https://${ApiGatewayRestApi}-${param:vpcEndpointId}.execute-api.${aws:region}.amazonaws.com/${sls:stage}
     CORS_CREDENTIALS: false
     IMAGERY_BUCKET_ARN: ${param:s3BucketArn}
   iam:


### PR DESCRIPTION
The fix for the `STAC_API_URL` was missing a key part which is the `ApiGatewayRestApi`, so this pull request adds that to the `STAC_API_URL` in the `serverless-private-api.yml` configuration file.